### PR TITLE
Removed MudServices Injection in ServiceCollection

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Add GitHub Packages Source
       run:  |-

--- a/src/AstroPanda.Blazor.Toolkit/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AstroPanda.Blazor.Toolkit/Extensions/ServiceCollectionExtensions.cs
@@ -26,8 +26,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IComponentBus, ComponentBus>();
         services.AddScoped(sp => sp.GetRequiredService<IComponentBus>() as ComponentBus ?? new ComponentBus());
 
-        services.AddHttpClient();
-        services.AddMudServices();
+        services.AddHttpClient();        
         return services;
     }
 
@@ -45,8 +44,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IComponentBus, ComponentBus>();
         services.AddScoped(sp => sp.GetRequiredService<IComponentBus>() as ComponentBus ?? new ComponentBus());
 
-        services.AddHttpClient();
-        services.AddMudServices();
+        services.AddHttpClient();        
         return services;
     }
 


### PR DESCRIPTION
Removing the MudServices line from the DI registration, because 1. we shouldn't be in control of adding that and 2. If the end user upgrades to MudBlazor v7, they'll end up having duplicate things registered from a library we don't even control. I ran into that problem earlier.

- **Removed injection of MudServices in our own services**
- **Update checkout step for workflows**
