### PR TITLE
Splitting Assembly Informational Version to disclude commit hash on VersionLabel

### DIFF
--- a/src/AstroPanda.Blazor.Toolkit/Components/VersionLabel.razor
+++ b/src/AstroPanda.Blazor.Toolkit/Components/VersionLabel.razor
@@ -59,7 +59,12 @@
           var versionAttr = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
           if (versionAttr is not null)
           {
-            _version = versionAttr.InformationalVersion;
+            var version = versionAttr.InformationalVersion;
+            
+             if (string.IsNullOrWhiteSpace(version))
+                version = "0.0.0";       
+            
+            _version = version.Split('+').FirstOrDefault() ?? "0.0.0";
           }
         }
         break;


### PR DESCRIPTION
I made this PR, because I noticed that the new way to read the assembly version includes the commit hash after a `+` char so this cleans it up a bit